### PR TITLE
added package requirements to container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,5 @@ RUN cargo build --release --bin gitlobster
 
 FROM debian:bullseye-slim AS runtime
 COPY --from=builder /app/target/release/gitlobster /usr/local/bin/gitlobster
+RUN apt update && apt install -yqq ca-certificates git
 ENTRYPOINT ["/usr/local/bin/gitlobster"]


### PR DESCRIPTION
HTTPS calls were failing due to untrusted certificates.
Program was exiting `os error 2: file not found`.

- Install root certificates package
- Install `git` binary that `Git` crate calls